### PR TITLE
use MixedModelsMakie.clevelandaxes! in data plot

### DIFF
--- a/notebooks/sleepstudy_speed.jl
+++ b/notebooks/sleepstudy_speed.jl
@@ -1,15 +1,16 @@
 ### A Pluto.jl notebook ###
-# v0.14.5
+# v0.14.7
 
 using Markdown
 using InteractiveUtils
 
 # ╔═╡ f9030e18-e484-11ea-24e0-3132afabdf83
 begin
-	using Arrow, DataFrames, CategoricalArrays, Chain
-	using Statistics, LinearAlgebra
-	using MixedModels, MixedModelsMakie
-	using AlgebraOfGraphics, CairoMakie
+	using CairoMakie         # device driver for static (SVG, PDF, PNG) plots
+	using Chain              # like pipes but cleaner
+	using DataFrames
+	using MixedModels
+	using MixedModelsMakie   # plots specific to mixed-effects models using Makie
 end
 
 # ╔═╡ 1357b670-e484-11ea-2275-cba956358da4
@@ -57,71 +58,39 @@ md"""
 First we attach the various packages needed, define a few helper functions, read the data, and get everything in the desired shape.
 """
 
-# ╔═╡ ae074801-0697-4811-baef-76e8ca8fac86
-function viewdf(x)
-	DataFrame(Arrow.Table(take!(Arrow.write(IOBuffer(), x))))
-end
-
-# ╔═╡ 5d02bc2b-5ae4-4017-a482-a35fb144b3cf
-md"""
-Two simple regression functions. **RK:** Why does the first one not work here?
-
-**DB:** It is because the `[...]` notation is evaluated at the time of function definition, not function evaluation.
-I changed the first function to use `hcat` and the second to return a Tuple instead of a vector.
-"""
-
-# ╔═╡ 51b19e16-b24c-4332-b5b8-6d5a5605f397
-linreg1(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:AbstractFloat} = hcat(ones(length(x)), x)\y
-
-# ╔═╡ f1d7982a-0a5c-40ae-8e09-9976cb49ea0f
-function simplelinreg(x, y)
-    A = cholesky!(Symmetric([length(x) sum(x) sum(y); 0.0 sum(abs2, x) dot(x, y); 0.0 0.0 sum(abs2, y)])).factors
-    (ldiv!(UpperTriangular(view(A, 1:2, 1:2)), view(A, 1:2, 3))...,)
-end
-
 # ╔═╡ e09a7f5c-1b17-4d60-958c-b84807c6638e
 md"## Preprocessing"
 
 # ╔═╡ 786e3abe-e4ae-11ea-0965-6bbd681d0f72
 md"""
 The `sleepstudy` data are one of the datasets available with recent versions of the `MixedModels` package. We carry out some preprocessing to have the dataframe in the desired shape:
-+ Capitalize random factor `Subj` (-- is not a factor yet --)
++ Capitalize random factor `Subj`
 + Compute `speed` as an alternative dependent variable from `reaction`, warranted by a 'boxcox' check of residuals. 
-+ Compute a sort index giving for `Subj`s' mean `speed`
-+ Covert `Subj` to CategoricalArray (i.e., factor)
-+ Relevel `Subj` according to speed-based sort index
-
-**DB:** I changed the name from data to df because the name data is used in AlgebraOfGraphics
-
-**DB:** I think it will be better to use a GroupedDataFrame and just extract the order.  I will write that up under a separate PR.
++ Create a `GroupedDataFrame` by levels of `Subj` (the original dataframe is available as `gdf.parent`, which we name `df`)
 """
 
 # ╔═╡ 66a6f3bc-e485-11ea-2b47-13a48b5d7e52
-begin
-	df = @chain DataFrame(MixedModels.dataset("sleepstudy")) begin
-		rename!(:subj => :Subj, :days => :day)
-	    transform!(:reaction => (x -> 1000 ./ x) => :speed)
-	end
-	ix = sort(combine(groupby(df, :Subj), :speed => mean), :speed_mean)
-	transform!(df, :Subj => (v -> levels!(categorical(v), ix.Subj)) => :Subj)
-	viewdf(df)
+gdf = @chain begin
+	DataFrame(MixedModels.dataset("sleepstudy"))
+	rename!(:subj => :Subj, :days => :day)
+	transform!(:reaction => (x -> 1000 ./ x) => :speed)
+	groupby(:Subj)
 end
 
 # ╔═╡ 61076594-0398-40c9-9190-08c820c6da97
-describe(df)
+begin
+	df = gdf.parent
+	describe(df)
+end
 
 # ╔═╡ 44adec0b-eec0-4b85-9161-01c11525c831
 md""" ## Estimates for pooled data
 
-In the first analysis we ignore the dependency of observvations due to repeated measures from the same subjects. We pool all the data and estimate the regression of 180 speed scores on the nine dayse of the experiment. We store the estimates for each `Subj`.
+In the first analysis we ignore the dependency of observations due to repeated measures from the same subjects. We pool all the data and estimate the regression of 180 speed scores on the nine days of the experiment.
 """
 
 # ╔═╡ da75674a-aca1-4aa1-8d71-5dde799f7e90
-begin
-	coef = simplelinreg(df.day, df.speed)
-	pld = DataFrame(Subj=ix.Subj, day_0=coef[1], effect=coef[2], 
-		  estimate = "Pooled");
-end
+pooledcoef = simplelinreg(df.day, df.speed)  # produces a Tuple
 
 # ╔═╡ 6d60ce3a-2ac9-447c-8a44-d185b8562a2d
 md"""
@@ -131,91 +100,30 @@ In the second analysis we estimate coefficients for each `Subj` without regard o
 
 ### Within-subject simple regressions
 
-+ Define dataframe to hold within-`Subj` effects
-+ Compute the simple regression of speed on day for every `Subj` (i.e., the within-subject effects of sleep deprivation). 
-
-The `(Intercept)` returns the estimate of `speed` at day 0, that is an estimate of `speed` prior to the experimental days, assuming that`day_0` corresponds to day B in the original study. 
+Applying `combine` to a grouped data frame like `gdf` produces a `DataFrame` with a row for each group.
+The permutation `ord` provides an ordering for the groups by increasing intercept (predicted response at day 0).
 """
 
 # ╔═╡ 651afde1-6fe6-418e-bcd4-f95c167d7305
-begin
-  wss = DataFrame(Subj=ix.Subj, day_0 = .0, effect = .0, estimate = "within-Subj" );
-  for i in 1:length(ix.Subj)
-  	local subj_df
-  	subj_df = filter(row -> row.Subj == ix.Subj[i], df) 
-  	wss[i, 2:3] = simplelinreg(subj_df.day, subj_df.speed)
-  end
-  wss
-end
+within = combine(gdf, [:day, :speed] => simplelinreg => :coef)
+
+# ╔═╡ 872d5023-5d98-436d-a2c0-03492d9579b2
+ord = sortperm(first.(within.coef))
+
 
 # ╔═╡ 071124e6-ba1c-4d83-b5fc-97e7a45f762c
 md" ### Figure of within-subject data and simple regressions"
 
-# ╔═╡ 7e4f18b9-e226-45f7-9d85-45ff9f7a6992
+# ╔═╡ 076b7ef7-7532-43a3-811f-78eb69cf865c
 begin
-	fSubj = Figure(resolution = (1600,1200))
-	x = LinRange(0, 9, 10)
-	y = LinRange(2, 5.5, 8) 
-	local faxs
-	faxs =  [Axis(fSubj[1, i]) for i in 1:6]
-	for i in 1:6
-		  Box(fSubj[1, i, Top()], backgroundcolor = :gray)
-		Label(fSubj[1, i, Top()], wss.Subj[i], padding = (5, 5, 5, 5))
-		local subj_df
-  	    subj_df = filter(row -> row.Subj == ix.Subj[i], df) 
-		scatter!(faxs[i], subj_df.day, subj_df.speed)
-		local y
-		y = wss.day_0[i] .+ wss.effect[i] .* x
-		lines!(faxs[i], x, y,  color = :blue, linewidth = 4)
+	labs = values(only.(keys(gdf)))[ord]       # labels for panels
+	f = clevelandaxes!(Figure(resolution=(1000,750)), labs, (2, 9))
+	for (axs, sdf) in zip(f.content, gdf[ord]) # iterate over the panels and groups
+		scatter!(axs, sdf.day, sdf.speed)      # add the points
+		coef = simplelinreg(sdf.day, sdf.speed)
+		abline!(axs, first(coef), last(coef))  # add the regression line
 	end
-	faxs[3].xlabel = "Day"                         # only one x-axis label
-	faxs[1].ylabel = "Speed [1000/RT]"             # only one y-axis label
-	hideydecorations!.(faxs[2:end], grid = false)  # ylab only on left panel
-	linkaxes!(faxs...)                             # use the same axes 
-	colgap!(fSubj.layout, 10);                      # tighten spacing btw panels
-end
-
-# ╔═╡ ede622d9-36ec-4950-90af-d7b6ac0cbd3d
-begin
-	local faxs
-	faxs =  [Axis(fSubj[2, i]) for i in 1:6]
-	for i in 1:6
-		  Box(fSubj[2, i, Top()], backgroundcolor = :gray)
-		Label(fSubj[2, i, Top()], wss.Subj[i+6], padding = (5, 5, 5, 5))
-		local subj_df
-  	    subj_df = filter(row -> row.Subj == ix.Subj[i+6], df) 
-		scatter!(faxs[i], subj_df.day, subj_df.speed)
-		local y
-		y = wss.day_0[i+6] .+ wss.effect[i+6] .* x
-		lines!(faxs[i], x, y,  color = :blue, linewidth = 4)
-	end
-	faxs[3].xlabel = "Day"                         # only one x-axis label
-	faxs[1].ylabel = "Speed [1000/RT]"             # only one y-axis label
-	hideydecorations!.(faxs[2:end], grid = false)  # ylab only on left panel
-	linkaxes!(faxs...)                             # use the same axes 
-	colgap!(fSubj.layout, 10)                       # tighten spacing btw panels
-end
-
-# ╔═╡ 2b5e7a1c-4798-4734-af15-b5aa1029e1e7
-begin
-	local faxs
-	faxs =  [Axis(fSubj[3, i]) for i in 1:6]
-	for i in 1:6
-		  Box(fSubj[3, i, Top()], backgroundcolor = :gray)
-		Label(fSubj[3, i, Top()], wss.Subj[i+12], padding = (5, 5, 5, 5))
-		local subj_df
-  	    subj_df = filter(row -> row.Subj == ix.Subj[i+12], df) 
-		scatter!(faxs[i], subj_df.day, subj_df.speed)
-		local y
-		y = wss.day_0[i+12] .+ wss.effect[i+12] .* x
-		lines!(faxs[i], x, y,  color = :blue, linewidth = 4)
-	end
-	faxs[3].xlabel = "Day"                         # only one x-axis label
-	faxs[1].ylabel = "Speed [1000/RT]"             # only one y-axis label
-	hideydecorations!.(faxs[2:end], grid = false)  # ylab only on left panel
-	linkaxes!(faxs...)                             # use the same axes 
-	colgap!(fSubj.layout, 10)                      # tighten spacing btw panels
-	fSubj
+	f
 end
 
 # ╔═╡ f3ed171c-e4ab-11ea-1eac-8b0265a6c6ea
@@ -238,7 +146,7 @@ md"##  No correlation parameter: zcp LMM"
 
 # ╔═╡ 3e3b227c-e4ad-11ea-3c24-fb23d26e1171
 md"""
-The `zerocorr` function applied to a random-effects term estimates one paremeter less than LMM `m1`-- the CP is now fixed to zero.
+The `zerocorr` function applied to a random-effects term estimates one parameter less than LMM `m1`-- the CP is now fixed to zero.
 """
 
 # ╔═╡ d68c3c14-e485-11ea-0b41-6d234ab4b676
@@ -246,7 +154,7 @@ m2 = fit(MixedModel, @formula(speed ~ 1+day+zerocorr(1+day|Subj)),df)
 
 # ╔═╡ 8e066b36-e4ad-11ea-2655-47a9a8d3c031
 md"""
-LMM `m2` has a slghtly  lower log-likelihood than LMM `m1` but also one parameter less.  The likelihood-ratio test is used to compare these nested models.
+LMM `m2` has a slghtly  lower log-likelihood than LMM `m1` but also one fewer parameters.  The likelihood-ratio test is used to compare these nested models.
 """
 
 # ╔═╡ ec436546-e485-11ea-19b8-a15f2f8247df
@@ -269,21 +177,6 @@ The third set of estimates are their conditional modes. They represent a comprom
 
 """
 
-# ╔═╡ 7d74a757-8336-4476-9f2e-4c2493cf2b5e
-cms = wss
-
-# ╔═╡ 0fb18a9c-7fda-45bf-bd29-c341a41854d2
-md" ## Combine the three types of estimates" 
-
-# ╔═╡ 3abc830c-4e1a-4d09-beec-46e6ff9f6cbf
-begin
-	cms_wss_pld = @chain vcat(cms, wss, pld) begin
-       transform!(:estimate => (v -> levels!(categorical(v), 
-		["Conditional mean", "within-Subj", "Pooled"])) => :estimate)
-	end
-	viewdf(cms_wss_pld)
-end
-
 # ╔═╡ bc413a49-d082-40aa-8c9b-e3d64904f6cf
 md" ## Three types of individual response profiles"
 
@@ -292,23 +185,20 @@ md"""
 Here we compare the three types on individual response profiles -- pooled, within-`Subj`, and based on conditional means of random effects.
 """
 
+# ╔═╡ 2a424308-be20-4062-9957-887e9edf6a34
+only(shrinkage(m2))
+
 # ╔═╡ 87fd5191-9ff9-4f34-a6ed-eda19c7a6ae2
 md" ## Caterpillar plots (effect profiles)"
 
 # ╔═╡ 31b8e4c1-55d7-47b6-850a-d5356490b046
-begin
-	cm_m2 = ranefinfo(m2)[:Subj];
-	caterpillar!(Figure(; resolution=(800,600)), cm_m2; orderby=1)
-end
+caterpillar(m2)
 
 # ╔═╡ 168bcc03-7969-4b6a-bb2c-c1d4c18a9f4f
 md" ## Shrinkage plot"
 
 # ╔═╡ d29f6377-e8ae-40dc-b084-d31e14728edd
-begin
-	shrnk_m2 = shrinkage(m2)[:Subj];
-	shrinkageplot!(Figure(; resolution=(800,600)), shrnk_m2)
-end
+shrinkageplot(m2)
 
 # ╔═╡ Cell order:
 # ╟─1357b670-e484-11ea-2275-cba956358da4
@@ -316,22 +206,17 @@ end
 # ╟─bf6eab08-e484-11ea-21b3-79b2acabd22f
 # ╟─44d5f548-e4ae-11ea-13c2-ddb1bbed274e
 # ╠═f9030e18-e484-11ea-24e0-3132afabdf83
-# ╠═ae074801-0697-4811-baef-76e8ca8fac86
-# ╠═5d02bc2b-5ae4-4017-a482-a35fb144b3cf
-# ╠═51b19e16-b24c-4332-b5b8-6d5a5605f397
-# ╠═f1d7982a-0a5c-40ae-8e09-9976cb49ea0f
 # ╟─e09a7f5c-1b17-4d60-958c-b84807c6638e
 # ╟─786e3abe-e4ae-11ea-0965-6bbd681d0f72
-# ╟─66a6f3bc-e485-11ea-2b47-13a48b5d7e52
+# ╠═66a6f3bc-e485-11ea-2b47-13a48b5d7e52
 # ╠═61076594-0398-40c9-9190-08c820c6da97
 # ╟─44adec0b-eec0-4b85-9161-01c11525c831
-# ╟─da75674a-aca1-4aa1-8d71-5dde799f7e90
+# ╠═da75674a-aca1-4aa1-8d71-5dde799f7e90
 # ╟─6d60ce3a-2ac9-447c-8a44-d185b8562a2d
-# ╟─651afde1-6fe6-418e-bcd4-f95c167d7305
+# ╠═651afde1-6fe6-418e-bcd4-f95c167d7305
+# ╠═872d5023-5d98-436d-a2c0-03492d9579b2
 # ╟─071124e6-ba1c-4d83-b5fc-97e7a45f762c
-# ╠═7e4f18b9-e226-45f7-9d85-45ff9f7a6992
-# ╠═ede622d9-36ec-4950-90af-d7b6ac0cbd3d
-# ╠═2b5e7a1c-4798-4734-af15-b5aa1029e1e7
+# ╠═076b7ef7-7532-43a3-811f-78eb69cf865c
 # ╟─f3ed171c-e4ab-11ea-1eac-8b0265a6c6ea
 # ╠═8a902898-e485-11ea-2d50-b3c44d666f9c
 # ╟─06560c54-e4ac-11ea-3b36-e57ee4bc3134
@@ -343,11 +228,9 @@ end
 # ╟─d0856ae0-e4ab-11ea-0016-2f170c65768f
 # ╠═9b0956f5-e02f-4235-ba24-49e75fe71169
 # ╟─a17bb040-d483-479d-8bbd-36f723f67a66
-# ╠═7d74a757-8336-4476-9f2e-4c2493cf2b5e
-# ╟─0fb18a9c-7fda-45bf-bd29-c341a41854d2
-# ╟─3abc830c-4e1a-4d09-beec-46e6ff9f6cbf
-# ╠═bc413a49-d082-40aa-8c9b-e3d64904f6cf
-# ╠═dab9ed8c-1deb-495b-901c-59a0c7ffcb26
+# ╟─bc413a49-d082-40aa-8c9b-e3d64904f6cf
+# ╟─dab9ed8c-1deb-495b-901c-59a0c7ffcb26
+# ╠═2a424308-be20-4062-9957-887e9edf6a34
 # ╟─87fd5191-9ff9-4f34-a6ed-eda19c7a6ae2
 # ╠═31b8e4c1-55d7-47b6-850a-d5356490b046
 # ╟─168bcc03-7969-4b6a-bb2c-c1d4c18a9f4f


### PR DESCRIPTION
This uses the clevelandaxes! (questionable name - we can change it to something better later) to set up the axes for a lattice::xyplot-style of multi-panel data plot. At present it needs the db/slrAsTuple branch of MixedModelsMakie. Depending on how @palday is adjusting to the time zone change he may be able to approve and merge that change in the next couple of days.